### PR TITLE
Add ICP 备案信息 and author credit to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,14 @@
       color: var(--muted);
       font-size: 0.95rem;
     }
+
+    .footnote a {
+      color: var(--muted);
+    }
+
+    .footnote a:hover {
+      color: var(--text);
+    }
   </style>
 </head>
 <body>
@@ -208,7 +216,9 @@
   </section>
 
   <section id="about" class="footnote">
-    Crafted with care. 一起记录开发中的灵光一现与代码日常。
+    <div>Crafted with care. 一起记录开发中的灵光一现与代码日常。</div>
+    <div>工信部备案号：陕ICP备17021455号-4 · <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">工信部备案地址</a></div>
+    <div>Created By MchWang.</div>
   </section>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add the MIIT ICP registration number and an official备案 link in the site footer for compliance and provide an explicit author credit.
- Ensure footer links visually match the muted footer styling and have a hover color for accessibility.

### Description
- Updated `index.html` to replace the single footer line with three `div` entries containing the existing message, the ICP record (`陕ICP备17021455号-4`) with a link to `https://beian.miit.gov.cn/`, and the text `Created By MchWang.`.
- Added CSS rules for `.footnote a` and `.footnote a:hover` to match the muted theme and change color on hover.
- Change is limited to `index.html` and only affects footer content and styles.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran an automated Playwright script that loaded `http://127.0.0.1:8000/` and produced a full-page screenshot `artifacts/footer.png`, which completed successfully.
- Patch was applied and served without errors during the automated page render test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671357faec832fbefc6fe904d37872)